### PR TITLE
rewrite build target

### DIFF
--- a/.ado/ghazdo.yml
+++ b/.ado/ghazdo.yml
@@ -1,0 +1,44 @@
+# ASP.NET
+# Build and test ASP.NET projects.
+# Add steps that publish symbols, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: AdvancedSecurity-Dependency-Scanning@1
+
+# Disable MVC Build Views compilation without modifying source code
+- pwsh: |
+    $filePath = (Join-Path $pwd '\MVCSampleProject.csproj')
+    $csproj = [xml](Get-Content $filePath)
+    $buildTargetNode = $csproj.Project.Target | ? name -eq "MvcBuildViews"
+    $buildTargetNode.SetAttribute("Condition", "'`$(MvcBuildViews)'=='false'")
+    $csproj.Save($filePath)
+
+- task: AdvancedSecurity-Codeql-Init@1
+  inputs:
+    languages: 'csharp'
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+- task: AdvancedSecurity-Codeql-Analyze@1
+  

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,20 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Do not build views by fooling the target
+      run: | 
+        $filePath = (Join-Path $pwd '\MVCSampleProject.csproj')
+        $csproj = [xml](Get-Content $filePath)
+        $buildTargetNode = $csproj.Project.Target | ? name -eq "MvcBuildViews"
+        $buildTargetNode.SetAttribute("Condition", "'`$(MvcBuildViews)'=='false'")
+        $csproj.Save($filePath)
+      shell: pwsh
+
+    - name: upload csproj
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        path: '*.csproj'      
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -82,3 +96,6 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+
+
+        


### PR DESCRIPTION
https://github.com/github/codeql/issues/11890#issuecomment-1496970164

tweaking the csproj file with powershell during the GitHub Action so that the hard-coded condition "gets fooled", basically. Something like this:

```
$filePath = (Join-Path $pwd '\SUBFOLDER\YOURCSPROJFILE.csproj')
$csproj = [xml](Get-Content $filePath)
$buildTargetNode = $csproj.Project.Target | ? name -eq "MvcBuildViews"
$buildTargetNode.SetAttribute("Condition", "'`$(MvcBuildViews)'=='false'")
$csproj.Save($filePath)
```
Here is the [output via build artifact](https://github.com/testing-felickz/MVCSampleProject/actions/runs/8100023954) when running the script:

```diff
-  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
-    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
-  </Target>
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='false'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
```


Also, added sample config pipeline confirmed working for GHAzDO:
https://github.com/testing-felickz/MVCSampleProject/blob/e23e1d1a15010309d91a61226c67b12e95000163/.ado/ghazdo.yml#L26-L32