### PR TITLE
Remove bad code - THIS IS THE BEST OPTION TO ALLOW VIEW ENGINE TO COMPILE FOR BEST SECURITY COVERAGE

### DIFF
--- a/Views/BadExcludedView.cshtml
+++ b/Views/BadExcludedView.cshtml
@@ -1,4 +1,6 @@
-﻿@model MVCSampleProject.FilterConfig.DOESNOTEXIST
+@*
+@model MVCSampleProject.FilterConfig.DOESNOTEXIST
+*@
 
 @{
     Layout = null;


### PR DESCRIPTION
This pull request includes a minor change to the `Views/BadExcludedView.cshtml` file. The change comments out the `@model` directive that was referencing a non-existing model `MVCSampleProject.FilterConfig.DOESNOTEXIST`. This modification will prevent any errors caused by this nonexistent reference during MVCBuildViews precompilation.